### PR TITLE
Define `dev` overlay with `podinfo`

### DIFF
--- a/apps/overlays/dev/kustomization.yaml
+++ b/apps/overlays/dev/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: podinfo-system
+
+resources:
+  - ../../base/podinfo
+
+patches:
+  - path: podinfo/version.yaml

--- a/apps/overlays/dev/podinfo/version.yaml
+++ b/apps/overlays/dev/podinfo/version.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+spec:
+  template:
+    spec:
+      containers:
+      - name: podinfod
+        image: ghcr.io/stefanprodan/podinfo:6.5.3

--- a/profiles/dev/apps.yaml
+++ b/profiles/dev/apps.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./apps/overlays/dev
+  prune: true
+  wait: true

--- a/profiles/dev/flux-system/gotk-sync.yaml
+++ b/profiles/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: podinfo-dev
   secretRef:
     name: flux-system
   url: ssh://git@github.com/fmilichovsky/gitops-demo

--- a/profiles/dev/flux-system/gotk-sync.yaml
+++ b/profiles/dev/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: podinfo-dev
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/fmilichovsky/gitops-demo


### PR DESCRIPTION
References `podinfo` in a new `dev` overlay, which is included in the `dev` profile.