### PR TITLE
Add regional podinfo settings

### DIFF
--- a/apps/overlays/production-eu/kustomization.yaml
+++ b/apps/overlays/production-eu/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - ../../base/podinfo
 
+components:
+  - ../../variants/podinfo-eu
+
 patches:
   - path: podinfo/version.yaml

--- a/apps/overlays/production-us/kustomization.yaml
+++ b/apps/overlays/production-us/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - ../../base/podinfo
 
+components:
+  - ../../variants/podinfo-us
+
 patches:
   - path: podinfo/version.yaml

--- a/apps/overlays/staging-eu/kustomization.yaml
+++ b/apps/overlays/staging-eu/kustomization.yaml
@@ -4,5 +4,9 @@ kind: Kustomization
 resources:
   - ../../base/podinfo
 
+
+components:
+  - ../../variants/podinfo-eu
+
 patches:
   - path: podinfo/version.yaml

--- a/apps/overlays/staging-us/kustomization.yaml
+++ b/apps/overlays/staging-us/kustomization.yaml
@@ -4,5 +4,8 @@ kind: Kustomization
 resources:
   - ../../base/podinfo
 
+components:
+  - ../../variants/podinfo-us
+
 patches:
   - path: podinfo/version.yaml

--- a/apps/variants/podinfo-eu/kustomization.yaml
+++ b/apps/variants/podinfo-eu/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: settings.yaml

--- a/apps/variants/podinfo-eu/settings.yaml
+++ b/apps/variants/podinfo-eu/settings.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+spec:
+  template:
+    spec:
+      containers:
+      - name: podinfod
+        env:
+        - name: REGION
+          value: EU
+        - name: GDPR_ENABLED
+          value: true

--- a/apps/variants/podinfo-us/kustomization.yaml
+++ b/apps/variants/podinfo-us/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: settings.yaml

--- a/apps/variants/podinfo-us/settings.yaml
+++ b/apps/variants/podinfo-us/settings.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: podinfo
+spec:
+  template:
+    spec:
+      containers:
+      - name: podinfod
+        env:
+        - name: REGION
+          value: US


### PR DESCRIPTION
Adds regional variants/components with arbitrary adjustments, links them up to the appropriate staging/prod profiles.