### PR TITLE
Diverge podinfo versions

### DIFF
--- a/apps/overlays/production-eu/podinfo/version.yaml
+++ b/apps/overlays/production-eu/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.3
+        image: ghcr.io/stefanprodan/podinfo:6.4.1

--- a/apps/overlays/production-us/podinfo/version.yaml
+++ b/apps/overlays/production-us/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.3
+        image: ghcr.io/stefanprodan/podinfo:6.5.0

--- a/apps/overlays/staging-eu/podinfo/version.yaml
+++ b/apps/overlays/staging-eu/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.3
+        image: ghcr.io/stefanprodan/podinfo:6.5.1

--- a/apps/overlays/staging-us/podinfo/version.yaml
+++ b/apps/overlays/staging-us/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.3
+        image: ghcr.io/stefanprodan/podinfo:6.5.0


### PR DESCRIPTION
Rolls back `podinfo` versions on higher-tier environments to artificially create drift.