### PR TITLE
Define separate registries for each overlay

### DIFF
--- a/apps/overlays/dev/kustomization.yaml
+++ b/apps/overlays/dev/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 patches:
   - path: podinfo/version.yaml
   - path: podinfo/_tracing.yaml
+
+transformers:
+  - registry.yaml

--- a/apps/overlays/dev/podinfo/version.yaml
+++ b/apps/overlays/dev/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.3
+        image: podinfo:6.5.3

--- a/apps/overlays/dev/registry.yaml
+++ b/apps/overlays/dev/registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: image-registry
+
+prefix: internal-dev-registry/
+
+fieldSpecs:
+- path: spec/template/spec/containers/image
+- path: spec/template/spec/initContainers/image

--- a/apps/overlays/production-eu/kustomization.yaml
+++ b/apps/overlays/production-eu/kustomization.yaml
@@ -10,3 +10,6 @@ components:
 patches:
   - path: podinfo/version.yaml
   - path: podinfo/_billing.yaml
+
+transformers:
+  - registry.yaml

--- a/apps/overlays/production-eu/podinfo/version.yaml
+++ b/apps/overlays/production-eu/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.4.1
+        image: podinfo:6.4.1

--- a/apps/overlays/production-eu/registry.yaml
+++ b/apps/overlays/production-eu/registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: image-registry
+
+prefix: internal-prod-registry/
+
+fieldSpecs:
+- path: spec/template/spec/containers/image
+- path: spec/template/spec/initContainers/image

--- a/apps/overlays/production-us/kustomization.yaml
+++ b/apps/overlays/production-us/kustomization.yaml
@@ -10,3 +10,6 @@ components:
 patches:
   - path: podinfo/version.yaml
   - path: podinfo/_billing.yaml
+
+transformers:
+  - registry.yaml

--- a/apps/overlays/production-us/podinfo/version.yaml
+++ b/apps/overlays/production-us/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.0
+        image: podinfo:6.5.0

--- a/apps/overlays/production-us/registry.yaml
+++ b/apps/overlays/production-us/registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: image-registry
+
+prefix: internal-prod-registry/
+
+fieldSpecs:
+- path: spec/template/spec/containers/image
+- path: spec/template/spec/initContainers/image

--- a/apps/overlays/staging-eu/kustomization.yaml
+++ b/apps/overlays/staging-eu/kustomization.yaml
@@ -4,9 +4,11 @@ kind: Kustomization
 resources:
   - ../../base/podinfo
 
-
 components:
   - ../../variants/podinfo-eu
 
 patches:
   - path: podinfo/version.yaml
+
+transformers:
+  - registry.yaml

--- a/apps/overlays/staging-eu/podinfo/version.yaml
+++ b/apps/overlays/staging-eu/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.1
+        image: podinfo:6.5.1

--- a/apps/overlays/staging-eu/registry.yaml
+++ b/apps/overlays/staging-eu/registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: image-registry
+
+prefix: internal-staging-registry/
+
+fieldSpecs:
+- path: spec/template/spec/containers/image
+- path: spec/template/spec/initContainers/image

--- a/apps/overlays/staging-us/kustomization.yaml
+++ b/apps/overlays/staging-us/kustomization.yaml
@@ -9,3 +9,6 @@ components:
 
 patches:
   - path: podinfo/version.yaml
+
+transformers:
+  - registry.yaml

--- a/apps/overlays/staging-us/podinfo/version.yaml
+++ b/apps/overlays/staging-us/podinfo/version.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       containers:
       - name: podinfod
-        image: ghcr.io/stefanprodan/podinfo:6.5.0
+        image: podinfo:6.5.0

--- a/apps/overlays/staging-us/registry.yaml
+++ b/apps/overlays/staging-us/registry.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: PrefixTransformer
+metadata:
+  name: image-registry
+
+prefix: internal-staging-registry/
+
+fieldSpecs:
+- path: spec/template/spec/containers/image
+- path: spec/template/spec/initContainers/image


### PR DESCRIPTION
Removes the registry part from specific versions patches and moves it into prefixTransformers.

This allow file-based promotions of version patches in cases where each environment might have a different dedicated registry.